### PR TITLE
Fix out of sync poll count

### DIFF
--- a/orkes-redis-queues/src/main/java/io/orkes/conductor/mq/ConductorQueue.java
+++ b/orkes-redis-queues/src/main/java/io/orkes/conductor/mq/ConductorQueue.java
@@ -51,6 +51,8 @@ public interface ConductorQueue {
 
     String getShardName();
 
+    int getPollCount();
+
     default double getScore(long now, QueueMessage msg) {
         double score = 0;
         if (msg.getTimeout() > 0) {

--- a/orkes-redis-queues/src/main/java/io/orkes/conductor/mq/redis/QueueMonitor.java
+++ b/orkes-redis-queues/src/main/java/io/orkes/conductor/mq/redis/QueueMonitor.java
@@ -151,4 +151,8 @@ public abstract class QueueMonitor {
             log.warn(t.getMessage(), t);
         }
     }
+
+    public int getPollCount() {
+        return pollCount.get();
+    }
 }

--- a/orkes-redis-queues/src/main/java/io/orkes/conductor/mq/redis/QueueMonitor.java
+++ b/orkes-redis-queues/src/main/java/io/orkes/conductor/mq/redis/QueueMonitor.java
@@ -146,7 +146,10 @@ public abstract class QueueMonitor {
                 message.setExpiry(messageExpiry);
                 peekedMessages.add(message);
             }
-            pollCount.addAndGet(-1 * (response.size() / 2));
+            pollCount.addAndGet(-1 * response.size());
+            if (pollCount.get() < 0) {
+                pollCount.set(0);
+            }
         } catch (Throwable t) {
             log.warn(t.getMessage(), t);
         }

--- a/orkes-redis-queues/src/main/java/io/orkes/conductor/mq/redis/QueueMonitor.java
+++ b/orkes-redis-queues/src/main/java/io/orkes/conductor/mq/redis/QueueMonitor.java
@@ -146,7 +146,7 @@ public abstract class QueueMonitor {
                 message.setExpiry(messageExpiry);
                 peekedMessages.add(message);
             }
-            pollCount.addAndGet(-1 * (response.size()/2));
+            pollCount.addAndGet(-1 * (response.size() / 2));
         } catch (Throwable t) {
             log.warn(t.getMessage(), t);
         }

--- a/orkes-redis-queues/src/main/java/io/orkes/conductor/mq/redis/QueueMonitor.java
+++ b/orkes-redis-queues/src/main/java/io/orkes/conductor/mq/redis/QueueMonitor.java
@@ -56,7 +56,7 @@ public abstract class QueueMonitor {
     public List<QueueMessage> pop(int count, int waitTime, TimeUnit timeUnit) {
 
         List<QueueMessage> messages = new ArrayList<>();
-        int pendingCount = pollCount.addAndGet(count);
+        int pendingCount = pollCount.getAndSet(Math.max(pollCount.get(), count));
         if (peekedMessages.isEmpty()) {
             __peekedMessages();
         } else if (peekedMessages.size() < pendingCount) {
@@ -146,10 +146,7 @@ public abstract class QueueMonitor {
                 message.setExpiry(messageExpiry);
                 peekedMessages.add(message);
             }
-            pollCount.addAndGet(-1 * response.size());
-            if (pollCount.get() < 0) {
-                pollCount.set(0);
-            }
+            pollCount.addAndGet(-1 * (response.size()/2));
         } catch (Throwable t) {
             log.warn(t.getMessage(), t);
         }

--- a/orkes-redis-queues/src/main/java/io/orkes/conductor/mq/redis/cluster/ConductorRedisClusterQueue.java
+++ b/orkes-redis-queues/src/main/java/io/orkes/conductor/mq/redis/cluster/ConductorRedisClusterQueue.java
@@ -170,6 +170,11 @@ public class ConductorRedisClusterQueue implements ConductorQueue {
         return null;
     }
 
+    @Override
+    public int getPollCount() {
+        return queueMonitor.getPollCount();
+    }
+
     private List<String> getPayloads(String[] messageIds) {
         List<String> payloads = jedis.hmget(payloadKey, messageIds);
         return payloads;

--- a/orkes-redis-queues/src/main/java/io/orkes/conductor/mq/redis/single/ConductorRedisQueue.java
+++ b/orkes-redis-queues/src/main/java/io/orkes/conductor/mq/redis/single/ConductorRedisQueue.java
@@ -183,6 +183,11 @@ public class ConductorRedisQueue implements ConductorQueue {
         return null;
     }
 
+    @Override
+    public int getPollCount() {
+        return queueMonitor.getPollCount();
+    }
+
     private List<String> getPayloads(String[] messageIds) {
         try (Jedis jedis = jedisPool.getResource()) {
             List<String> payloads = jedis.hmget(payloadKey, messageIds);

--- a/orkes-redis-queues/src/test/java/io/orkes/conductor/mq/ConductorRedisQueueTest.java
+++ b/orkes-redis-queues/src/test/java/io/orkes/conductor/mq/ConductorRedisQueueTest.java
@@ -12,7 +12,6 @@
  */
 package io.orkes.conductor.mq;
 
-import java.sql.Time;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.*;
@@ -307,17 +306,21 @@ public class ConductorRedisQueueTest {
         redisQueue.push(Arrays.asList(new QueueMessage(String.valueOf(1), "1", 0,1)));
         redisQueue.push(Arrays.asList(new QueueMessage(String.valueOf(2), "2", 0,1)));
 
-        List<QueueMessage> msg = redisQueue.pop(1, 100, TimeUnit.MILLISECONDS);
-        List<QueueMessage> msg1 = redisQueue.pop(1, 100, TimeUnit.MILLISECONDS);
-        List<QueueMessage> msg2 = redisQueue.pop(1, 100, TimeUnit.MILLISECONDS);
+        redisQueue.pop(1, 100, TimeUnit.MILLISECONDS);
+        redisQueue.pop(1, 100, TimeUnit.MILLISECONDS);
+        //Pop 10 times
+        for(int i=0;i<10;i++) {
+            redisQueue.pop(1, 100, TimeUnit.MILLISECONDS);
+        }
+        // Pollcount should not change
+        assertEquals(1, redisQueue.getPollCount());
 
         redisQueue.push(Arrays.asList(new QueueMessage(String.valueOf(3), "3", 0,1)));
         redisQueue.push(Arrays.asList(new QueueMessage(String.valueOf(4), "4", 0,1)));
-        List<QueueMessage> msg3 = redisQueue.pop(1, 100, TimeUnit.MILLISECONDS);
-        assertEquals(msg.size(), 1);
-        assertEquals(msg1.size(), 1);
-        assertEquals(msg2.size(), 0);
-        assertEquals(msg3.size(), 1);
+        assertEquals(1, redisQueue.getPollCount());
+
+        redisQueue.pop(2, 100, TimeUnit.MILLISECONDS);
+        assertEquals(0, redisQueue.getPollCount());
     }
 
     @Test

--- a/orkes-redis-queues/src/test/java/io/orkes/conductor/mq/ConductorRedisQueueTest.java
+++ b/orkes-redis-queues/src/test/java/io/orkes/conductor/mq/ConductorRedisQueueTest.java
@@ -300,6 +300,25 @@ public class ConductorRedisQueueTest {
         redisQueue.flush();
         assertEquals(0, redisQueue.size());
     }
+    @Test
+    public void testPollCountOrdering() {
+        ConductorRedisQueue redisQueue = new ConductorRedisQueue("test",jedisPool);
+
+        redisQueue.push(Arrays.asList(new QueueMessage(String.valueOf(1), "1", 0,1)));
+        redisQueue.push(Arrays.asList(new QueueMessage(String.valueOf(2), "2", 0,1)));
+
+        List<QueueMessage> msg = redisQueue.pop(1, 100, TimeUnit.MILLISECONDS);
+        List<QueueMessage> msg1 = redisQueue.pop(1, 100, TimeUnit.MILLISECONDS);
+        List<QueueMessage> msg2 = redisQueue.pop(1, 100, TimeUnit.MILLISECONDS);
+
+        redisQueue.push(Arrays.asList(new QueueMessage(String.valueOf(3), "3", 0,1)));
+        redisQueue.push(Arrays.asList(new QueueMessage(String.valueOf(4), "4", 0,1)));
+        List<QueueMessage> msg3 = redisQueue.pop(1, 100, TimeUnit.MILLISECONDS);
+        assertEquals(msg.size(), 1);
+        assertEquals(msg1.size(), 1);
+        assertEquals(msg2.size(), 0);
+        assertEquals(msg3.size(), 1);
+    }
 
     @Test
     public void testPriority() {


### PR DESCRIPTION
Rationale:- The pollCount was getting incremented on each poll and it will be as max Pollcount after 100th poll. So after that even if we poll for 1, the queue will poll for 100 and return only 1. This leaves 99 entries in memory. This can cause nondeterministic behavior if the server goes down after this. 