### PR TITLE
Adding Redis ACL support with username

### DIFF
--- a/orkes-conductor-queues/src/main/java/io/orkes/conductor/queue/config/QueueRedisProperties.java
+++ b/orkes-conductor-queues/src/main/java/io/orkes/conductor/queue/config/QueueRedisProperties.java
@@ -68,6 +68,9 @@ public class QueueRedisProperties {
     /** Database number. Defaults to a 0. Can be anywhere from 0 to 15 */
     private int database = 0;
 
+    /** The username to be used for connecting to redis if using Auth with ACL */
+    private String username = null;
+
     /**
      * The maximum amount of time to wait for a connection to become available from the connection
      * pool
@@ -266,6 +269,14 @@ public class QueueRedisProperties {
 
     public void setDatabase(int database) {
         this.database = database;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
     }
 
     public String getQueuePrefix() {

--- a/orkes-conductor-queues/src/main/java/io/orkes/conductor/queue/config/RedisQueueConfiguration.java
+++ b/orkes-conductor-queues/src/main/java/io/orkes/conductor/queue/config/RedisQueueConfiguration.java
@@ -90,7 +90,18 @@ public class RedisQueueConfiguration {
                 redisProperties.isSsl());
         Host host = hostSupplier.getHosts().get(0);
 
-        if (host.getPassword() != null) {
+        if (redisProperties.getUsername() != null &&  host.getPassword() != null) {
+            log.info("Connecting to Redis Standalone with ACL user AUTH");
+            return new JedisPool(
+                    config,
+                    host.getHostName(),
+                    host.getPort(),
+                    Protocol.DEFAULT_TIMEOUT,
+                    redisProperties.getUsername(),
+                    host.getPassword(),
+                    redisProperties.getDatabase(),
+                    redisProperties.isSsl());
+        } else if (host.getPassword() != null) {
             log.info("Connecting to Redis Standalone with AUTH");
             return new JedisPool(
                     config,
@@ -136,7 +147,24 @@ public class RedisQueueConfiguration {
         }
         // We use the password of the first sentinel host as password and sentinelPassword
         String password = getPassword(hostSupplier.getHosts());
-        if (password != null) {
+        if (properties.getUsername() != null && password != null) {
+            return new JedisSentinelPool(
+                    properties.getClusterName(),
+                    sentinels,
+                    genericObjectPoolConfig,
+                    Protocol.DEFAULT_TIMEOUT,
+                    Protocol.DEFAULT_TIMEOUT,
+                    properties.getUsername(),
+                    password,
+                    properties.getDatabase(),
+                    null,
+                    Protocol.DEFAULT_TIMEOUT,
+                    Protocol.DEFAULT_TIMEOUT,
+                    properties.getUsername(),
+                    password,
+                    null);
+
+        } else if (password != null) {
             return new JedisSentinelPool(
                     properties.getClusterName(),
                     sentinels,


### PR DESCRIPTION
This is follow up to https://github.com/Netflix/conductor/pull/3847
To have the same support added to Orkes queues.

It adds ACL user based auth support for Redis to conductor properties. 
https://redis.io/docs/management/security/acl/