### PR TITLE
Allow setting unack without pushing further in the queue

### DIFF
--- a/orkes-conductor-queues/src/main/java/io/orkes/conductor/mq/ConductorQueue.java
+++ b/orkes-conductor-queues/src/main/java/io/orkes/conductor/mq/ConductorQueue.java
@@ -68,6 +68,21 @@ public interface ConductorQueue {
     boolean setUnacktimeout(String messageId, long unackTimeout);
 
     /**
+     * Sets the unack timeout for a message only if the new delivery time is sooner than the
+     * currently scheduled one — i.e. never extends the existing timeout. Implementations that
+     * support an atomic "update-if-lower" operation (e.g. {@code ZADD XX LT} in Redis) should
+     * override this method. The default falls back to an unconditional {@link
+     * #setUnacktimeout(String, long)}.
+     *
+     * @param messageId the message id
+     * @param unackTimeout the new unack timeout in milliseconds
+     * @return true if the timeout was updated
+     */
+    default boolean setUnacktimeoutIfShorter(String messageId, long unackTimeout) {
+        return setUnacktimeout(messageId, unackTimeout);
+    }
+
+    /**
      * Checks if a message exists in the queue.
      *
      * @param messageId the message id to check

--- a/orkes-conductor-queues/src/main/java/io/orkes/conductor/mq/redis/cluster/ConductorRedisClusterQueue.java
+++ b/orkes-conductor-queues/src/main/java/io/orkes/conductor/mq/redis/cluster/ConductorRedisClusterQueue.java
@@ -100,6 +100,18 @@ public class ConductorRedisClusterQueue implements ConductorQueue {
     }
 
     @Override
+    public boolean setUnacktimeoutIfShorter(String messageId, long unackTimeout) {
+        double score = clock.millis() + unackTimeout;
+        ZAddParams params =
+                ZAddParams.zAddParams()
+                        .xx() // only update, do NOT add
+                        .lt() // only update if new score is less (sooner delivery)
+                        .ch(); // return modified elements count
+        Long modified = jedis.zadd(queueName, score, messageId, params);
+        return modified != null && modified > 0;
+    }
+
+    @Override
     public boolean exists(String messageId) {
         Double score = jedis.zscore(queueName, messageId);
         if (score != null) {

--- a/orkes-conductor-queues/src/main/java/io/orkes/conductor/mq/redis/single/ConductorRedisQueue.java
+++ b/orkes-conductor-queues/src/main/java/io/orkes/conductor/mq/redis/single/ConductorRedisQueue.java
@@ -107,6 +107,18 @@ public class ConductorRedisQueue implements ConductorQueue {
     }
 
     @Override
+    public boolean setUnacktimeoutIfShorter(String messageId, long unackTimeout) {
+        double score = clock.millis() + unackTimeout;
+        ZAddParams params =
+                ZAddParams.zAddParams()
+                        .xx() // only update, do NOT add
+                        .lt() // only update if new score is less (sooner delivery)
+                        .ch(); // return modified elements count
+        Long modified = jedis.zadd(queueName, score, messageId, params);
+        return modified != null && modified > 0;
+    }
+
+    @Override
     public boolean exists(String messageId) {
         Double score = jedis.zscore(queueName, messageId);
         if (score != null) {

--- a/orkes-conductor-queues/src/test/java/io/orkes/conductor/mq/AbstractConductorQueueTest.java
+++ b/orkes-conductor-queues/src/test/java/io/orkes/conductor/mq/AbstractConductorQueueTest.java
@@ -126,6 +126,70 @@ public abstract class AbstractConductorQueueTest {
         assertFalse(updated);
     }
 
+    /**
+     * When the new timeout would deliver the message sooner than currently scheduled, {@code
+     * setUnacktimeoutIfShorter} must update the score and return {@code true}.
+     */
+    @Test
+    public void testSetUnacktimeoutIfShorterShortensDueTime() {
+        getQueue().flush();
+
+        String id = UUID.randomUUID().toString();
+        QueueMessage msg = new QueueMessage(id, "payload-" + id);
+        msg.setTimeout(5_000); // 5 seconds — well out of reach
+        getQueue().push(Arrays.asList(msg));
+
+        assertNull(popOne()); // not yet available
+
+        // Shorten delivery to 100 ms — score should move forward
+        boolean shortened = getQueue().setUnacktimeoutIfShorter(id, 100);
+        assertTrue(
+                shortened, "setUnacktimeoutIfShorter should return true when it actually shortens");
+
+        Uninterruptibles.sleepUninterruptibly(200, TimeUnit.MILLISECONDS);
+
+        QueueMessage popped = popOne();
+        assertNotNull(popped, "message should be available after the shortened timeout");
+        assertEquals(id, popped.getId());
+    }
+
+    /**
+     * When the new timeout would deliver the message later than currently scheduled, {@code
+     * setUnacktimeoutIfShorter} must leave the score unchanged and return {@code false}.
+     */
+    @Test
+    public void testSetUnacktimeoutIfShorterDoesNotExtend() {
+        getQueue().flush();
+
+        String id = UUID.randomUUID().toString();
+        QueueMessage msg = new QueueMessage(id, "payload-" + id);
+        msg.setTimeout(300); // 300 ms
+        getQueue().push(Arrays.asList(msg));
+
+        // Attempt to push the delivery out to 10 s — must be rejected
+        boolean extended = getQueue().setUnacktimeoutIfShorter(id, 10_000);
+        assertFalse(
+                extended,
+                "setUnacktimeoutIfShorter must not extend an already-closer delivery time");
+
+        assertNull(popOne()); // still not available within the original 300 ms window
+
+        // Original 300 ms elapses — message must appear at its original time, not 10 s later
+        Uninterruptibles.sleepUninterruptibly(400, TimeUnit.MILLISECONDS);
+        QueueMessage popped = popOne();
+        assertNotNull(popped, "message should be available after its original 300 ms timeout");
+        assertEquals(id, popped.getId());
+    }
+
+    /** {@code setUnacktimeoutIfShorter} on a non-existent message must return {@code false}. */
+    @Test
+    public void testSetUnacktimeoutIfShorterForNonExistentMessage() {
+        getQueue().flush();
+        boolean updated =
+                getQueue().setUnacktimeoutIfShorter("nonexistent-" + UUID.randomUUID(), 500);
+        assertFalse(updated);
+    }
+
     @Test
     public void testConcurrency() throws InterruptedException, ExecutionException {
         getQueue().flush();


### PR DESCRIPTION
Use case
1. The task is scheduled to be delivered in 3 seconds
2. Allow setting unack value such that it remains 3 - if the process tries to set to 5 sec, it does not change offset
3. Useful when two tasks have different timeouts and we want smaller one to be the one taking effect