### PR TITLE
Add peekFirstIds for inspecting postponed messages without popping

### DIFF
--- a/orkes-conductor-queues/src/main/java/io/orkes/conductor/mq/ConductorQueue.java
+++ b/orkes-conductor-queues/src/main/java/io/orkes/conductor/mq/ConductorQueue.java
@@ -44,6 +44,20 @@ public interface ConductorQueue {
     List<QueueMessage> pop(int count, int waitTime, TimeUnit timeUnit);
 
     /**
+     * Returns the first {@code count} message ids ordered by score, regardless of whether their
+     * visibility (deliver) time has elapsed. Intended for inspecting or releasing postponed
+     * messages without popping them — e.g. when a concurrency-limit slot frees and a postponed
+     * task should be made immediately available.
+     *
+     * @param count the maximum number of message ids to return
+     * @return message ids in queue order (earliest score first); empty if the queue has no
+     *     pending messages
+     */
+    default List<String> peekFirstIds(int count) {
+        return List.of();
+    }
+
+    /**
      * Acknowledges a message, removing it from the queue.
      *
      * @param messageId the message id to acknowledge

--- a/orkes-conductor-queues/src/main/java/io/orkes/conductor/mq/redis/cluster/ConductorRedisClusterQueue.java
+++ b/orkes-conductor-queues/src/main/java/io/orkes/conductor/mq/redis/cluster/ConductorRedisClusterQueue.java
@@ -70,6 +70,11 @@ public class ConductorRedisClusterQueue implements ConductorQueue {
     }
 
     @Override
+    public List<String> peekFirstIds(int count) {
+        return jedis.zrangeByScore(queueName, 0, Double.POSITIVE_INFINITY, 0, count);
+    }
+
+    @Override
     public boolean ack(String messageId) {
 
         long removed = jedis.zrem(queueName, messageId);

--- a/orkes-conductor-queues/src/main/java/io/orkes/conductor/mq/redis/single/ConductorRedisQueue.java
+++ b/orkes-conductor-queues/src/main/java/io/orkes/conductor/mq/redis/single/ConductorRedisQueue.java
@@ -67,6 +67,11 @@ public class ConductorRedisQueue implements ConductorQueue {
     }
 
     @Override
+    public List<String> peekFirstIds(int count) {
+        return jedis.zrangeByScore(queueName, 0, Double.POSITIVE_INFINITY, 0, count);
+    }
+
+    @Override
     public boolean ack(String messageId) {
         Long removed;
         removed = jedis.zrem(queueName, messageId);

--- a/orkes-conductor-queues/src/test/java/io/orkes/conductor/mq/AbstractConductorQueueTest.java
+++ b/orkes-conductor-queues/src/test/java/io/orkes/conductor/mq/AbstractConductorQueueTest.java
@@ -501,6 +501,61 @@ public abstract class AbstractConductorQueueTest {
     }
 
     @Test
+    public void testPeekFirstIdsReturnsPostponedMessages() {
+        getQueue().flush();
+
+        String id = "peek-postponed-" + UUID.randomUUID();
+        QueueMessage msg = new QueueMessage(id, "payload");
+        msg.setTimeout(10_000); // far in the future — pop must not see it
+        getQueue().push(Arrays.asList(msg));
+
+        assertNull(popOne(), "pop must not return a postponed message");
+
+        List<String> peeked = getQueue().peekFirstIds(5);
+        assertEquals(1, peeked.size(), "peekFirstIds must surface postponed messages");
+        assertEquals(id, peeked.get(0));
+
+        // peek is non-destructive — message must still be in the queue afterwards
+        assertEquals(1, getQueue().size());
+    }
+
+    @Test
+    public void testPeekFirstIdsReturnsEarliestByScore() {
+        getQueue().flush();
+
+        QueueMessage soon = new QueueMessage("peek-soon-" + UUID.randomUUID(), "soon");
+        soon.setTimeout(500);
+        QueueMessage later = new QueueMessage("peek-later-" + UUID.randomUUID(), "later");
+        later.setTimeout(10_000);
+        // Push later first to confirm the order is by score, not by insertion order
+        getQueue().push(Arrays.asList(later, soon));
+
+        List<String> peeked = getQueue().peekFirstIds(2);
+        assertEquals(2, peeked.size());
+        assertEquals(soon.getId(), peeked.get(0), "earliest deliver-time must come first");
+        assertEquals(later.getId(), peeked.get(1));
+    }
+
+    @Test
+    public void testPeekFirstIdsRespectsCount() {
+        getQueue().flush();
+        for (int i = 0; i < 5; i++) {
+            QueueMessage msg = new QueueMessage("peek-count-" + i, "payload-" + i);
+            msg.setTimeout(10_000);
+            getQueue().push(Arrays.asList(msg));
+        }
+
+        assertEquals(2, getQueue().peekFirstIds(2).size());
+        assertEquals(5, getQueue().peekFirstIds(10).size(), "count > size must return all ids");
+    }
+
+    @Test
+    public void testPeekFirstIdsOnEmptyQueue() {
+        getQueue().flush();
+        assertTrue(getQueue().peekFirstIds(10).isEmpty());
+    }
+
+    @Test
     public void testRateLimitedQueue() {
         // This creates a queue with RATE_LIMITED_WORKFLOW in its name,
         // which exercises the non-cached (popStrict) path in QueueMonitor


### PR DESCRIPTION
## Summary

Adds `ConductorQueue.peekFirstIds(int count)` — returns the earliest `count` message ids by score, regardless of deliver-time visibility.

- **Interface** — `default` returning empty list, so non-Redis backends fall through transparently.
- **Single + cluster Redis** — `ZRANGEBYSCORE queueName 0 +inf LIMIT 0 count`.

## Why

Used by the concurrent-exec-limit fix on orkes-conductor (`fix/concurrent-exec-limit`): when a concurrency slot frees, the conductor needs to release a postponed task to the deciderQueue without waiting for its scheduled deliver time. Pop would consume it; peek lets us look up the id and explicitly postpone with a zero delay.

## Test plan
- [ ] Existing queue tests pass
- [ ] Wire-up verified against `fix/concurrent-exec-limit` in orkes-conductor
